### PR TITLE
Fix test with Python 3.10

### DIFF
--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -2667,6 +2667,8 @@ class TestNonAsciiResults(TestCase):
         """Syntax errors should still have fancy special-case formatting"""
         if platform.python_implementation() == "PyPy":
             spaces = '           '
+        elif sys.version_info >= (3, 10):
+            spaces = '        '
         else:
             spaces = '          '
         textoutput = self._test_external_case("exec ('f(a, b c)')")


### PR DESCRIPTION
Python 3.10 has changed the carat placement and adjusted the text in this case.

Merging this will update PR https://github.com/testing-cabal/testtools/pull/304.

# Python 3.9

```
testtools.testresult.real._StringException: Traceback (most recent call last):
  File "/var/folders/kt/j77sf4_n6fnbx6pg199rbx700000gn/T/TestNonAsciiResultsWithUnittest4yt0auid/test_syntax_error1.py", line 6, in runTest
    exec ('f(a, b c)')
  File "<string>", line 1
    f(a, b c)
           ^
SyntaxError: invalid syntax
```

# Python 3.10

```
testtools.testresult.real._StringException: Traceback (most recent call last):
  File "/var/folders/kt/j77sf4_n6fnbx6pg199rbx700000gn/T/TestNonAsciiResultsWithUnittesttxqfn7hx/test_syntax_error1.py", line 6, in runTest
    exec ('f(a, b c)')
  File "<string>", line 1
    f(a, b c)
         ^
SyntaxError: invalid syntax. Perhaps you forgot a comma?
```
